### PR TITLE
Align metallb-config chart with repository style

### DIFF
--- a/charts/infra/metallb-config/NOTES.txt
+++ b/charts/infra/metallb-config/NOTES.txt
@@ -1,0 +1,3 @@
+This chart configures MetalLB by creating IPAddressPool and L2Advertisement resources.
+
+Ensure MetalLB is installed in your cluster before deploying this chart.

--- a/charts/infra/metallb-config/README.md
+++ b/charts/infra/metallb-config/README.md
@@ -1,0 +1,20 @@
+# metallb-config
+
+![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+
+Generic MetalLB configuration (multiple pools, ads)
+
+## Requirements
+
+| Repository          | Name   | Version |
+| ------------------- | ------ | ------- |
+| file://../../common | common | 0.1.0   |
+
+## Values
+
+| Key               | Type   | Default | Description                 |
+| ----------------- | ------ | ------- | --------------------------- |
+| commonAnnotations | object | `{}`    |                             |
+| commonLabels      | object | `{}`    |                             |
+| pools             | list   | `[]`    | IPAddressPool definitions   |
+| l2Advertisements  | list   | `[]`    | L2Advertisement definitions |

--- a/charts/infra/metallb-config/templates/ipaddresspools.yaml
+++ b/charts/infra/metallb-config/templates/ipaddresspools.yaml
@@ -4,6 +4,15 @@ apiVersion: metallb.io/v1beta1
 kind: IPAddressPool
 metadata:
   name: {{ $pool.name | required "pool.name is required" | trunc 63 | trimSuffix "-" }}
+  labels:
+    {{- include "common.labels" $root | nindent 4 }}
+  {{- with $root.Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with $root.Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   addresses:
     {{- range $pool.addresses }}

--- a/charts/infra/metallb-config/templates/l2advertisements.yaml
+++ b/charts/infra/metallb-config/templates/l2advertisements.yaml
@@ -1,8 +1,18 @@
+{{- $root := . -}}
 {{- range $ad := .Values.l2Advertisements | default list }}
 apiVersion: metallb.io/v1beta1
 kind: L2Advertisement
 metadata:
   name: {{ $ad.name | required "l2Advertisements[].name is required" | trunc 63 | trimSuffix "-" }}
+  labels:
+    {{- include "common.labels" $root | nindent 4 }}
+  {{- with $root.Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with $root.Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   {{- with $ad.ipAddressPools }}
   ipAddressPools:

--- a/charts/infra/metallb-config/values.schema.json
+++ b/charts/infra/metallb-config/values.schema.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "commonLabels": { "type": "object", "additionalProperties": true },
+    "commonAnnotations": { "type": "object", "additionalProperties": true },
+    "pools": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": { "type": "string" },
+          "addresses": {
+            "type": "array",
+            "items": { "type": "string" }
+          },
+          "autoAssign": { "type": "boolean" },
+          "avoidBuggyIPs": { "type": "boolean" },
+          "serviceAllocation": {
+            "type": "object",
+            "properties": {
+              "priority": { "type": "integer" }
+            },
+            "additionalProperties": true
+          }
+        },
+        "required": ["name", "addresses"]
+      }
+    },
+    "l2Advertisements": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": { "type": "string" },
+          "ipAddressPools": {
+            "type": "array",
+            "items": { "type": "string" }
+          }
+        },
+        "required": ["name"]
+      }
+    }
+  }
+}

--- a/charts/infra/metallb-config/values.yaml
+++ b/charts/infra/metallb-config/values.yaml
@@ -1,12 +1,16 @@
+# Common labels/annotations applied to all resources
+commonLabels: {}
+commonAnnotations: {}
+
 pools:
   # Example public pool
   - name: public
     addresses:
       - 192.168.1.200-192.168.1.210
-    autoAssign: true           # optional
-    avoidBuggyIPs: true        # optional
+    autoAssign: true # optional
+    avoidBuggyIPs: true # optional
     serviceAllocation:
-      priority: 0              # optional (v1beta1: ServiceAllocation is optional)
+      priority: 0 # optional (v1beta1: ServiceAllocation is optional)
   # Example private pool
   - name: private
     addresses:


### PR DESCRIPTION
## Summary
- add commonLabels/commonAnnotations support and use common.label helper
- document metallb-config chart and add schema and notes

## Testing
- `helm lint charts/infra/metallb-config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a6252dd47483239070b5b4fe937099